### PR TITLE
当自己发出预警时，不进行预警声音的播放

### DIFF
--- a/TheGuideToTheNewEden/TheGuideToTheNewEden.Core/Models/ChannelIntel/ChannelIntelObserver.cs
+++ b/TheGuideToTheNewEden/TheGuideToTheNewEden.Core/Models/ChannelIntel/ChannelIntelObserver.cs
@@ -164,7 +164,9 @@ namespace TheGuideToTheNewEden.Core.Models.ChannelIntel
                                         IntelType = chatContent.IntelType == Enums.IntelChatType.Clear ? Enums.IntelChatType.Clear : Enums.IntelChatType.Intel,
                                         IntelMap = IntelMap,
                                         Jumps = jumps,
-                                        IntelShips = shipContents
+                                        IntelShips = shipContents,
+                                        // 2025-08-24 增加预警者名称的赋值
+                                        WarnerName = chatContent.SpeakerName,
                                     };
                                 }
                                 else

--- a/TheGuideToTheNewEden/TheGuideToTheNewEden.Core/Models/EarlyWarningContent.cs
+++ b/TheGuideToTheNewEden/TheGuideToTheNewEden.Core/Models/EarlyWarningContent.cs
@@ -32,6 +32,10 @@ namespace TheGuideToTheNewEden.Core.Models
         public int Jumps { get; set; }
 
         public List<IntelShipContent> IntelShips { get; set; }
+        /// <summary>
+        /// 2025-08-24 预警者名称
+        /// </summary>
+        public string WarnerName { get; set; }
     }
 
     public class IntelShipContent

--- a/TheGuideToTheNewEden/TheGuideToTheNewEden.WinUI/TheGuideToTheNewEden.WinUI/Services/WarningService.cs
+++ b/TheGuideToTheNewEden/TheGuideToTheNewEden.WinUI/TheGuideToTheNewEden.WinUI/Services/WarningService.cs
@@ -111,7 +111,8 @@ namespace TheGuideToTheNewEden.WinUI.Services
                         value.Show();
                         value.Intel(content);
                     }
-                    if (SoundNotifyItems.TryGetValue(listener, out var soundNotifyItem))
+                    // 2025-08-24 如果是自己发出的预警，则不播放预警声音
+                    if (SoundNotifyItems.TryGetValue(listener, out var soundNotifyItem) && listener != content.WarnerName)
                     {
                         soundNotifyItem.PlaySound(soundSetting);
                     }


### PR DESCRIPTION
如果设置了报警声音循环播放，每当自己发出预警信息后，需要额外的操作关闭报警声音。
当预警信息是自己发出，不进行预警声音的播放更便捷